### PR TITLE
Enable Async by default

### DIFF
--- a/pipeline.patch
+++ b/pipeline.patch
@@ -294,7 +294,7 @@ index 51e7140..06e9142 100644
  
    DxvkOptions::DxvkOptions(const Config& config) {
      allowMemoryOvercommit = config.getOption<bool>("dxvk.allowMemoryOvercommit", false);
-+    asyncPipeCompiler     = config.getOption<bool>("dxvk.asyncPipeCompiler",     false);
++    asyncPipeCompiler     = config.getOption<bool>("dxvk.asyncPipeCompiler",     true);
    }
  
  }


### PR DESCRIPTION
Since people will be using this patch to enable async, they will probably want to have it enabled by default