### PR TITLE
Fix compile errors

### DIFF
--- a/pipeline.patch
+++ b/pipeline.patch
@@ -445,7 +445,7 @@ index 0000000..e62721a
 +
 +
 +  void DxvkPipelineCompiler::runCompilerThread() {
-+    env::setThreadName(L"dxvk-pcompiler");
++    env::setThreadName("dxvk-pcompiler");
 +
 +    while (!m_compilerStop.load()) {
 +      PipelineEntry entry;


### PR DESCRIPTION
Tried to compile with v0.95, and it threw an error:
`[84/193] Compiling C++ object 'src/dxvk/dxvk@sta/dxvk_pipecompiler.cpp.obj'.
FAILED: src/dxvk/dxvk@sta/dxvk_pipecompiler.cpp.obj 
x86_64-w64-mingw32-g++  -Isrc/dxvk/dxvk@sta -Isrc/dxvk -I../../../root/dxvk/src/dxvk -I../../../root/dxvk/./include -I. -fdiagnostics-color=always -pipe -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++1z -O3 -DNOMINMAX -pthread -MD -MQ 'src/dxvk/dxvk@sta/dxvk_pipecompiler.cpp.obj' -MF 'src/dxvk/dxvk@sta/dxvk_pipecompiler.cpp.obj.d' -o 'src/dxvk/dxvk@sta/dxvk_pipecompiler.cpp.obj' -c ../../../root/dxvk/src/dxvk/dxvk_pipecompiler.cpp
../../../root/dxvk/src/dxvk/dxvk_pipecompiler.cpp: In member function 'void dxvk::DxvkPipelineCompiler::runCompilerThread()':
../../../root/dxvk/src/dxvk/dxvk_pipecompiler.cpp:46:41: error: invalid initialization of reference of type 'const string& {aka const std::__cxx11::basic_string<char>&}' from expression of type 'const wchar_t [15]'
     env::setThreadName(L"dxvk-pcompiler");
                                         ^
In file included from ../../../root/dxvk/src/dxvk/dxvk_include.h:6:0,
                 from ../../../root/dxvk/src/dxvk/dxvk_descriptor.h:5,
                 from ../../../root/dxvk/src/dxvk/dxvk_buffer.h:6,
                 from ../../../root/dxvk/src/dxvk/dxvk_bind_mask.h:3,
                 from ../../../root/dxvk/src/dxvk/dxvk_graphics.h:5,
                 from ../../../root/dxvk/src/dxvk/dxvk_pipecompiler.cpp:1:
../../../root/dxvk/src/dxvk/../util/util_env.h:32:8: note: in passing argument 1 of 'void dxvk::env::setThreadName(const string&)'
   void setThreadName(const std::string& name);
        ^~~~~~~~~~~~~
[101/193] Compiling C++ object 'src/dxvk/dxvk@sta/dxvk_state_cache.cpp.obj'.
ninja: build stopped: subcommand failed.
`
I don't know much about the code, but it seems to me like a missclick. Compiled after the change and works with PoE.