### PR TITLE
Fix entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-DXVK_VERSION=$1
+DXVK_VERSION=$1 #Put the desired version instead $1 - for example v0.95
 
 git clone https://github.com/doitsujin/dxvk
 cd dxvk
 git checkout "$DXVK_VERSION"
-git apply /root/pipeline.patch
-./package-release.sh "$DXVK_VERSION" /output --no-package
+git apply ../pipeline.patch
+./package-release.sh "$DXVK_VERSION" ../ --no-package
 
 exec "$@"


### PR DESCRIPTION
The original does not find pipeline.patch and does not find the folder for the compiled binaries. Fixed.