### PR TITLE
Enable auto-enabling for specific games in config

### DIFF
--- a/pipeline.patch
+++ b/pipeline.patch
@@ -558,11 +558,35 @@ index 682db83d..2783c847 100644
      if (useStateCache != "0" && device->config().enableStateCache)
        m_stateCache = new DxvkStateCache(device, this, passManager);
 +
-+    if (useAsync == "1")
++    if (useAsync == "1" || device->config().useAsync)
 +      m_compiler = new DxvkPipelineCompiler();
    }
    
    
+diff --git a/src/dxvk/dxvk_options.cpp b/src/dxvk/dxvk_options.cpp
+index e1da8a48..9d6b4ee9 100644
+--- a/src/dxvk/dxvk_options.cpp
++++ b/src/dxvk/dxvk_options.cpp
+@@ -4,6 +4,7 @@ namespace dxvk {
+ 
+   DxvkOptions::DxvkOptions(const Config& config) {
+     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);
++    useAsync              = config.getOption<bool>    ("dxvk.useAsync",               false);
+     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
+     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
+     useEarlyDiscard = config.getOption<Tristate>("dxvk.useEarlyDiscard", Tristate::Auto);
+diff --git a/src/dxvk/dxvk_options.h b/src/dxvk/dxvk_options.h
+index 79259875..db2f8a32 100644
+--- a/src/dxvk/dxvk_options.h
++++ b/src/dxvk/dxvk_options.h
+@@ -10,6 +10,7 @@ namespace dxvk {
+ 
+     /// Enable state cache
+     bool enableStateCache;
++    bool useAsync;
+ 
+     /// Number of compiler threads
+     /// when using the state cache
 diff --git a/src/dxvk/dxvk_pipemanager.h b/src/dxvk/dxvk_pipemanager.h
 index fb62cb9a..c3b846cf 100644
 --- a/src/dxvk/dxvk_pipemanager.h
@@ -608,3 +632,38 @@ index 64f20998..bd11e390 100644
    'dxvk_pipelayout.cpp',
    'dxvk_pipemanager.cpp',
    'dxvk_queue.cpp',
+diff --git a/src/util/config/config.cpp b/src/util/config/config.cpp
+index 4b40c2cb..998ba73a 100644
+--- a/src/util/config/config.cpp
++++ b/src/util/config/config.cpp
+@@ -138,6 +138,30 @@ namespace dxvk {
+     { "starwarsbattlefronttrial.exe", {{
+       { "dxgi.nvapiHack",                   "False" },
+     }} },
++    /* Warframe         */
++    { "Warframe.x64.exe", {{
++      { "dxvk.useAsync",                   "True" },
++    }} },
++    /* Warframe         */
++    { "Warframe.exe", {{
++      { "dxvk.useAsync",                   "True" },
++    }} },
++    /* Path of Exile         */
++    { "PathOfExile_x64Steam.exe", {{
++      { "dxvk.useAsync",                   "True" },
++    }} },
++    /* Path of Exile         */
++    { "PathOfExileSteam.exe", {{
++      { "dxvk.useAsync",                   "True" },
++    }} },
++    /* Path of Exile         */
++    { "PathOfExile.exe", {{
++      { "dxvk.useAsync",                   "True" },
++    }} },
++    /* Path of Exile         */
++    { "PathOfExile_x64.exe", {{
++      { "dxvk.useAsync",                   "True" },
++    }} },
+     /* Dark Souls Remastered                      */
+     { "DarkSoulsRemastered.exe", {{
+       { "d3d11.constantBufferRangeCheck",   "True" },


### PR DESCRIPTION
This adds a device config option so that specific game executables can have the patch automatically enabled, preventing the need to set DXVK_ASYNC=1 for games known to work well and be safe to use with the patch. Currently it is only enabled for Warframe and Path of Exile.